### PR TITLE
Add api_key authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,17 @@ When adding support for a new object, or updating existing code, it can be usefu
 TrueNAS machine from time to time. In order to help do that easily, you can drop a `.auth.yaml` file in the root of
 the repository, with the following content:
 
-```
+```yaml
 host: "some.host.name"
 username: "someuser"
 password: "somepassword"
+```
+
+Alternatively, an api key can be used:
+
+```yaml
+host: "some.host.name"
+api_key: "someapikey"
 ```
 
 Use `scripts/invoke_method.py` to call a method:

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ from aiotruenas_client import CachingMachine as TrueNASMachine
 
 machine = await TrueNASMachine.create(
     "hostname.of.machine",
-    username="someuser",
-    password="password",
+    api_key="someapikey"
 )
 disks = await machine.get_disks()
 pools = await machine.get_pools()
 vms = await machine.get_vms()
 ```
+
+Alternatively, a username and password may also be supplied.
 
 ### `Machine`
 
@@ -71,14 +72,6 @@ pre-commit install
 When adding support for a new object, or updating existing code, it can be useful to see the raw response from the
 TrueNAS machine from time to time. In order to help do that easily, you can drop a `.auth.yaml` file in the root of
 the repository, with the following content:
-
-```yaml
-host: "some.host.name"
-username: "someuser"
-password: "somepassword"
-```
-
-Alternatively, an api key can be used:
 
 ```yaml
 host: "some.host.name"

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -46,7 +46,7 @@ class CachingMachine(Machine):
         if password is not None and token is not None:
             raise ValueError("Only one of password and token can be used.")
         if password is None and token is None:
-            raise ValueError("Either password or token must be goven.")
+            raise ValueError("Either password or token must be given.")
         m = CachingMachine()
         await m.connect(
             host=host,

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -14,7 +14,7 @@ from .virtualmachine import CachingVirtualMachineStateFetcher, CachingVirtualMac
 from .protocol import (
     TrueNASWebSocketClientProtocol,
     truenas_password_auth_protocol_factory,
-    truenas_token_auth_protocol_factory,
+    truenas_api_key_auth_protocol_factory,
 )
 
 TCachingMachine = TypeVar("TCachingMachine", bound="CachingMachine")
@@ -41,19 +41,19 @@ class CachingMachine(Machine):
         password: Optional[str] = None,
         username: Optional[str] = "root",
         secure: bool = True,
-        token: Optional[str] = None,
+        api_key: Optional[str] = None,
     ) -> TCachingMachine:
-        if password is not None and token is not None:
-            raise ValueError("Only one of password and token can be used.")
-        if password is None and token is None:
-            raise ValueError("Either password or token must be given.")
+        if password is not None and api_key is not None:
+            raise ValueError("Only one of password and api_key can be used.")
+        if password is None and api_key is None:
+            raise ValueError("Either password or api_key must be given.")
         m = CachingMachine()
         await m.connect(
             host=host,
             password=password,
             username=username,
             secure=secure,
-            token=token,
+            api_key=api_key,
         )
         return m
 
@@ -63,13 +63,13 @@ class CachingMachine(Machine):
         password: Optional[str],
         username: Optional[str],
         secure: bool,
-        token: Optional[str],
+        api_key: Optional[str],
     ) -> None:
         """Connects to the remote machine."""
         if password is not None:
             auth_protocol = truenas_password_auth_protocol_factory(username, password)
-        if token is not None:
-            auth_protocol = truenas_token_auth_protocol_factory(token)
+        if api_key is not None:
+            auth_protocol = truenas_api_key_auth_protocol_factory(api_key)
         await self._connect(auth_protocol, host, secure)
 
     async def _connect(self, auth_protocol, host, secure):

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -43,10 +43,6 @@ class CachingMachine(Machine):
         secure: bool = True,
         api_key: Optional[str] = None,
     ) -> TCachingMachine:
-        if password is not None and api_key is not None:
-            raise ValueError("Only one of password and api_key can be used.")
-        if password is None and api_key is None:
-            raise ValueError("Either password or api_key must be given.")
         m = CachingMachine()
         await m.connect(
             host=host,
@@ -66,10 +62,18 @@ class CachingMachine(Machine):
         api_key: Optional[str],
     ) -> None:
         """Connects to the remote machine."""
-        if password is not None:
+        if password and api_key:
+            raise ValueError("Only one of password and api_key can be used.")
+        if password and not username:
+            raise ValueError("Username is missing.")
+        if not password and not api_key:
+            raise ValueError("Either password or api_key must be given.")
+
+        if password:
             auth_protocol = truenas_password_auth_protocol_factory(username, password)
-        if api_key is not None:
+        if api_key:
             auth_protocol = truenas_api_key_auth_protocol_factory(api_key)
+
         await self._connect(auth_protocol, host, secure)
 
     async def _connect(self, auth_protocol, host, secure):

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 import asyncio
 import ejson
 import functools
@@ -7,6 +6,7 @@ import pprint
 import uuid
 import websockets
 
+from abc import abstractmethod
 from typing import (
     Any,
     Callable,
@@ -120,7 +120,14 @@ class TrueNASWebSocketClientProtocol(WebSocketClientProtocol):
 
     @abstractmethod
     async def _authenticate(self):
-        """Authentication method."""
+        """
+        Authentication method.
+
+        Must call an `auth` websocket method and return result.  For example:
+        ```
+        return await self.invoke_method("auth.login_with_api_key", [self._api_key])
+        ```
+        """
 
     def _invoke_method_handler(self, message: Dict[str, Any]) -> None:
         if message["id"] not in self._invoke_method_futures:

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -174,15 +174,15 @@ class TrueNASWebSocketClientProtocolPassword(TrueNASWebSocketClientProtocol):
         return await self.invoke_method("auth.login", [self._username, self._password])
 
 
-class TrueNASWebSocketClientProtocolToken(TrueNASWebSocketClientProtocol):
+class TrueNASWebSocketClientProtocolApiKey(TrueNASWebSocketClientProtocol):
     """Token authentication."""
 
-    def __init__(self, *args, token: str, **kwargs):
+    def __init__(self, *args, api_key: str, **kwargs):
         super().__init__(*args, **kwargs)
-        self._token = token
+        self._api_key = api_key
 
     async def _authenticate(self):
-        return await self.invoke_method("auth.token", [self._token])
+        return await self.invoke_method("auth.login_with_api_key", [self._api_key])
 
 
 def truenas_password_auth_protocol_factory(
@@ -194,7 +194,7 @@ def truenas_password_auth_protocol_factory(
     )
 
 
-def truenas_token_auth_protocol_factory(
-    token: str,
-) -> Callable[[Any], TrueNASWebSocketClientProtocolToken]:
-    return functools.partial(TrueNASWebSocketClientProtocolToken, token=token)
+def truenas_api_key_auth_protocol_factory(
+    api_key: str,
+) -> Callable[[Any], TrueNASWebSocketClientProtocolApiKey]:
+    return functools.partial(TrueNASWebSocketClientProtocolApiKey, api_key=api_key)

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -119,7 +119,7 @@ class TrueNASWebSocketClientProtocol(WebSocketClientProtocol):
         return await sub_future
 
     @abstractmethod
-    async def _authenticate(self):
+    async def _authenticate(self) -> Any:
         """
         Authentication method.
 
@@ -179,7 +179,7 @@ class TrueNASWebSocketClientProtocolPassword(TrueNASWebSocketClientProtocol):
         self._username = username
         self._password = password
 
-    async def _authenticate(self):
+    async def _authenticate(self) -> Any:
         return await self.invoke_method("auth.login", [self._username, self._password])
 
 
@@ -190,7 +190,7 @@ class TrueNASWebSocketClientProtocolApiKey(TrueNASWebSocketClientProtocol):
         super().__init__(*args, **kwargs)
         self._api_key = api_key
 
-    async def _authenticate(self):
+    async def _authenticate(self) -> Any:
         return await self.invoke_method("auth.login_with_api_key", [self._api_key])
 
 

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import asyncio
 import ejson
 import functools
@@ -117,8 +118,9 @@ class TrueNASWebSocketClientProtocol(WebSocketClientProtocol):
         )
         return await sub_future
 
+    @abstractmethod
     async def _authenticate(self):
-        raise NotImplementedError
+        """Authentication method."""
 
     def _invoke_method_handler(self, message: Dict[str, Any]) -> None:
         if message["id"] not in self._invoke_method_futures:

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -117,6 +117,9 @@ class TrueNASWebSocketClientProtocol(WebSocketClientProtocol):
         )
         return await sub_future
 
+    async def _authenticate(self):
+        raise NotImplementedError
+
     def _invoke_method_handler(self, message: Dict[str, Any]) -> None:
         if message["id"] not in self._invoke_method_futures:
             logger.error(f"Message id %s is not one we are expecting!", message["id"])

--- a/scripts/invoke_method.py
+++ b/scripts/invoke_method.py
@@ -43,17 +43,30 @@ def init_argparse() -> argparse.ArgumentParser:
         "-u",
         help="The username to authenticiate with.  Loads from .auth.yaml if not present.",
     )
+    parser.add_argument(
+        "--api_key",
+        "-a",
+        help="The api_key to authenticiate with.  Loads from .auth.yaml if not present.",
+    )
+
     return parser
 
 
 async def invoke_method(
-    host: str, username: str, password: str, secure: bool, method: str, args: List[Any]
+    host: str,
+    username: str,
+    password: str,
+    secure: bool,
+    method: str,
+    api_key: str,
+    args: List[Any],
 ) -> None:
     print(f"Connecting to {host} to call {method}...")
     machine = await Machine.create(
         host=host,
         username=username,
         password=password,
+        api_key=api_key,
         secure=secure,
     )
     result = await machine._client.invoke_method(method, args)
@@ -72,6 +85,7 @@ if __name__ == "__main__":
     username = args.username
     password = args.password
     secure = not args.insecure
+    api_key = args.api_key
 
     try:
         with open(".auth.yaml", "r") as stream:
@@ -79,6 +93,7 @@ if __name__ == "__main__":
             host = data.get("host", args.host)
             username = data.get("username", args.username)
             password = data.get("password", args.password)
+            api_key = data.get("api_key", args.api_key)
     except IOError:
         pass
     asyncio.get_event_loop().run_until_complete(
@@ -87,6 +102,7 @@ if __name__ == "__main__":
             username=username,
             password=password,
             secure=secure,
+            api_key=api_key,
             method=args.method,
             args=json.loads(args.arguments),
         )

--- a/scripts/subscribe.py
+++ b/scripts/subscribe.py
@@ -36,6 +36,11 @@ def init_argparse() -> argparse.ArgumentParser:
         "-u",
         help="The username to authenticiate with.  Loads from .auth.yaml if not present.",
     )
+    parser.add_argument(
+        "--api_key",
+        "-a",
+        help="The api_key to authenticiate with.  Loads from .auth.yaml if not present.",
+    )
     return parser
 
 
@@ -45,12 +50,14 @@ async def subscribe(
     password: str,
     secure: bool,
     name: str,
+    api_key: str,
 ) -> None:
     print(f"Connecting to {host} to subscribe to {name}...")
     machine = await Machine.create(
         host=host,
         username=username,
         password=password,
+        api_key=api_key,
         secure=secure,
     )
     queue = await machine._client.subscribe(name)
@@ -72,6 +79,7 @@ if __name__ == "__main__":
     username = args.username
     password = args.password
     secure = not args.insecure
+    api_key = args.api_key
 
     try:
         with open(".auth.yaml", "r") as stream:
@@ -79,6 +87,7 @@ if __name__ == "__main__":
             host = data.get("host", args.host)
             username = data.get("username", args.username)
             password = data.get("password", args.password)
+            api_key = data.get("api_key", args.api_key)
     except IOError:
         pass
     asyncio.get_event_loop().run_until_complete(
@@ -87,6 +96,7 @@ if __name__ == "__main__":
             username=username,
             password=password,
             secure=secure,
+            api_key=api_key,
             name=args.name,
         )
     )

--- a/tests/fakes/fakeserver.py
+++ b/tests/fakes/fakeserver.py
@@ -29,6 +29,7 @@ class TrueNASServer(object):
 
     _username: str
     _password: str
+    _token: str
     _serve_handle: websockets.serve
 
     _method_handlers: Dict[str, TMethodHandler]
@@ -36,11 +37,17 @@ class TrueNASServer(object):
     def __init__(self):
         self._username = "".join(random.choice(string.ascii_letters) for i in range(6))
         self._password = "".join(random.choice(string.ascii_letters) for i in range(6))
+        self._token = "".join(random.choice(string.ascii_letters) for i in range(6))
         self._method_handlers = {}
 
         self.register_method_handler(
             "auth.login",
             lambda u, p: u == self.username and p == self.password,
+        )
+
+        self.register_method_handler(
+            "auth.token",
+            lambda t: t == self.token,
         )
 
         self._serve_handle = websockets.serve(self._handle_messages, "localhost", 8000)
@@ -74,6 +81,11 @@ class TrueNASServer(object):
     def host(self) -> str:
         """The host to use to connect to this server."""
         return "localhost:8000"
+
+    @property
+    def token(self) -> str:
+        """The token that will successfully authenticate with the server."""
+        return self._token
 
     async def _handle_messages(
         self, websocket: websockets.protocol.WebSocketCommonProtocol, _path: str

--- a/tests/fakes/fakeserver.py
+++ b/tests/fakes/fakeserver.py
@@ -29,7 +29,7 @@ class TrueNASServer(object):
 
     _username: str
     _password: str
-    _token: str
+    _api_key: str
     _serve_handle: websockets.serve
 
     _method_handlers: Dict[str, TMethodHandler]
@@ -37,7 +37,7 @@ class TrueNASServer(object):
     def __init__(self):
         self._username = "".join(random.choice(string.ascii_letters) for i in range(6))
         self._password = "".join(random.choice(string.ascii_letters) for i in range(6))
-        self._token = "".join(random.choice(string.ascii_letters) for i in range(6))
+        self._api_key = "".join(random.choice(string.ascii_letters) for i in range(6))
         self._method_handlers = {}
 
         self.register_method_handler(
@@ -46,8 +46,8 @@ class TrueNASServer(object):
         )
 
         self.register_method_handler(
-            "auth.token",
-            lambda t: t == self.token,
+            "auth.login_with_api_key",
+            lambda t: t == self.api_key,
         )
 
         self._serve_handle = websockets.serve(self._handle_messages, "localhost", 8000)
@@ -83,9 +83,9 @@ class TrueNASServer(object):
         return "localhost:8000"
 
     @property
-    def token(self) -> str:
-        """The token that will successfully authenticate with the server."""
-        return self._token
+    def api_key(self) -> str:
+        """The api_key that will successfully authenticate with the server."""
+        return self._api_key
 
     async def _handle_messages(
         self, websocket: websockets.protocol.WebSocketCommonProtocol, _path: str

--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -70,12 +70,18 @@ class TestCachingMachineAuth(IsolatedAsyncioTestCase):
             )
 
     async def test_unsuccessful_auth_no_username(self):
-        # username has default value "root"
         with self.assertRaises(ValueError):
             await CachingMachine.create(
                 self._server.host,
-                username=None,
                 password=self._server.password,
+                secure=False,
+            )
+
+    async def test_unsuccessful_auth_no_password(self):
+        with self.assertRaises(ValueError):
+            await CachingMachine.create(
+                self._server.host,
+                username=self._server.username,
                 secure=False,
             )
 

--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -36,29 +36,29 @@ class TestCachingMachineAuth(IsolatedAsyncioTestCase):
                 secure=False,
             )
 
-    async def test_successful_auth_token(self):
+    async def test_successful_auth_api_key(self):
         machine = await CachingMachine.create(
             self._server.host,
-            token=self._server.token,
+            api_key=self._server.api_key,
             secure=False,
         )
         await machine.close()
 
-    async def test_unsuccessful_auth_token(self):
+    async def test_unsuccessful_auth_api_key(self):
         with self.assertRaises(websockets.exceptions.SecurityError):
             await CachingMachine.create(
                 self._server.host,
-                token="not a real token",
+                api_key="not a real api_key",
                 secure=False,
             )
 
-    async def test_unsuccessful_auth_token_and_password(self):
+    async def test_unsuccessful_auth_api_key_and_password(self):
         with self.assertRaises(ValueError):
             await CachingMachine.create(
                 self._server.host,
                 username=self._server.username,
                 password=self._server.password,
-                token=self._server.token,
+                api_key=self._server.api_key,
                 secure=False,
             )
 

--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -63,10 +63,19 @@ class TestCachingMachineAuth(IsolatedAsyncioTestCase):
             )
 
     async def test_unsuccessful_auth_no_input(self):
+        with self.assertRaises(ValueError):
+            await CachingMachine.create(
+                self._server.host,
+                secure=False,
+            )
+
+    async def test_unsuccessful_auth_no_username(self):
         # username has default value "root"
         with self.assertRaises(ValueError):
             await CachingMachine.create(
                 self._server.host,
+                username=None,
+                password=self._server.password,
                 secure=False,
             )
 

--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -18,7 +18,7 @@ class TestCachingMachineAuth(IsolatedAsyncioTestCase):
     async def asyncTearDown(self):
         await self._server.stop()
 
-    async def test_successful_auth(self):
+    async def test_successful_auth_password(self):
         machine = await CachingMachine.create(
             self._server.host,
             username=self._server.username,
@@ -27,12 +27,46 @@ class TestCachingMachineAuth(IsolatedAsyncioTestCase):
         )
         await machine.close()
 
-    async def test_unsuccessful_auth(self):
+    async def test_unsuccessful_auth_password(self):
         with self.assertRaises(websockets.exceptions.SecurityError):
             await CachingMachine.create(
                 self._server.host,
                 username="not a real user",
                 password=self._server.password,
+                secure=False,
+            )
+
+    async def test_successful_auth_token(self):
+        machine = await CachingMachine.create(
+            self._server.host,
+            token=self._server.token,
+            secure=False,
+        )
+        await machine.close()
+
+    async def test_unsuccessful_auth_token(self):
+        with self.assertRaises(websockets.exceptions.SecurityError):
+            await CachingMachine.create(
+                self._server.host,
+                token="not a real token",
+                secure=False,
+            )
+
+    async def test_unsuccessful_auth_token_and_password(self):
+        with self.assertRaises(ValueError):
+            await CachingMachine.create(
+                self._server.host,
+                username=self._server.username,
+                password=self._server.password,
+                token=self._server.token,
+                secure=False,
+            )
+
+    async def test_unsuccessful_auth_no_input(self):
+        # username has default value "root"
+        with self.assertRaises(ValueError):
+            await CachingMachine.create(
+                self._server.host,
                 secure=False,
             )
 


### PR DESCRIPTION
This PR adds token authentication by adding a new parameter to `create` class method, and making the `password` parameter optional.

Fixes: #36 

