### PR TITLE
Add pytest to requirements-dev.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,8 @@ python scripts/subscribe.py reporting.realtime
 ```
 
 Run either with -h to see additional options.
+
+
+### Testing
+
+Tests are run with `pytest`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pre-commit==2.9.3
 black==20.8b1
+pytest==6.2.1


### PR DESCRIPTION
The tests are run by pytest in the CI.  This adds pytest to the dev requirements, pinned to the most recent version.