### PR TITLE
Support testing on Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version:
+          - 3.8
+          - 3.9
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.9 has come out, and Home Assistant requires it, so let's test on it too.