### PR TITLE
Handle Disk Serial Numbers with Leading/Trailing Whitespace

### DIFF
--- a/aiotruenas_client/disk.py
+++ b/aiotruenas_client/disk.py
@@ -21,7 +21,7 @@ class DiskType(Enum):
 
 class Disk(ABC):
     def __init__(self, serial: str) -> None:
-        self._serial = serial
+        self._serial = serial.strip()
 
     @property
     @abstractmethod

--- a/aiotruenas_client/websockets/disk.py
+++ b/aiotruenas_client/websockets/disk.py
@@ -130,7 +130,7 @@ class CachingDiskStateFetcher(object):
 
         # Disks should be keyed by serial for long-term storage (unique), but
         # it is easier to work by name above.
-        return {disk["serial"]: disk for disk in disks_by_name.values()}
+        return {disk["serial"].strip(): disk for disk in disks_by_name.values()}
 
     def _update_properties_from_state(self) -> None:
         available_disks_by_serial = {

--- a/tests/websockets/test_disk.py
+++ b/tests/websockets/test_disk.py
@@ -244,6 +244,28 @@ class TestDisk(IsolatedAsyncioTestCase):
         b = CachingDisk(self._machine._disk_fetcher, "ada0")
         self.assertEqual(a, b)
 
+    async def test_serial_with_edge_whitespace(self) -> None:
+        SERIAL = "NOTREALSERIAL"
+        self._server.register_method_handler(
+            "disk.query",
+            lambda *args: [
+                {
+                    "description": "Some Desc",
+                    "model": "Samsung SSD 860 EVO 250GB",
+                    "name": "ada0",
+                    "serial": f" {SERIAL} ",
+                    "size": 250059350016,
+                    "type": "SSD",
+                },
+            ],
+        )
+
+        await self._machine.get_disks()
+
+        self.assertEqual(len(self._machine.disks), 1)
+        disk = self._machine.disks[0]
+        self.assertEqual(disk.serial, SERIAL)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This seems like a pretty common thing, and we can just make this easier
for consumers who might care to access this property by trimming the
witespace automatically.

This change updates the code accordingly, and adds a test that fails
prior to the change.