### PR TITLE
Add a `closed` property to `CachingMachine`

### DIFF
--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -97,6 +97,11 @@ class CachingMachine(Machine):
         await self._client.close()
         self._client = None
 
+    @property
+    def closed(self) -> bool:
+        """Indicates if the connection to the server is closed or not."""
+        return self._client is None or self._client.closed
+
     async def get_disks(self, include_temperature: bool = False) -> List[CachingDisk]:
         """Returns a list of disks attached to the host."""
         return await self._disk_fetcher.get_disks(

--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -117,5 +117,22 @@ class TestCachingMachineGetSystemInfo(IsolatedAsyncioTestCase):
         self.assertEqual(info["hostname"], HOSTNAME)
 
 
+class TestCachingMachineClosed(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self._server = TrueNASServer()
+
+    async def test_closed(self) -> None:
+        machine = await CachingMachine.create(
+            self._server.host,
+            api_key=self._server.api_key,
+            secure=False,
+        )
+
+        self.assertFalse(machine.closed)
+
+        await self._server.stop()
+        self.assertTrue(machine.closed)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is a workaround for clients to deal with #29.  We do not have an
easy way to automatically re-estabilish the connection (at least today),
so this allows a client to check if it is closed, and restart the
connection itself.