### PR TITLE
Add support for Jobs

### DIFF
--- a/aiotruenas_client/job.py
+++ b/aiotruenas_client/job.py
@@ -1,0 +1,69 @@
+from abc import ABC, abstractmethod
+from enum import Enum, unique
+from typing import Any, Optional, TypeVar
+
+TJobId = int
+TJobStatus = TypeVar("TJobStatus", bound="JobStatus")
+
+
+@unique
+class JobStatus(Enum):
+    FAILED = "FAILED"
+    RUNNING = "RUNNING"
+    SUCCESS = "SUCCESS"
+    WAITING = "WAITING"
+
+    @classmethod
+    def fromValue(cls, value: str) -> TJobStatus:
+        if value == cls.FAILED.value:
+            return cls.FAILED
+        if value == cls.RUNNING.value:
+            return cls.RUNNING
+        if value == cls.SUCCESS.value:
+            return cls.SUCCESS
+        if value == cls.WAITING.value:
+            return cls.WAITING
+        raise AssertionError(f"Unexpected job state '{value}'")
+
+
+class Job(ABC):
+    def __init__(
+        self,
+        id: TJobId,
+        method: str,
+    ) -> None:
+        self._id = id
+        self._method = method
+
+    @property
+    @abstractmethod
+    def error(self) -> Optional[str]:
+        """The error message from the API."""
+
+    @property
+    def id(self) -> TJobId:
+        """The job identifying number."""
+        return self._id
+
+    @property
+    def method(self) -> str:
+        """The method that created the job."""
+        return self._method
+
+    @property
+    @abstractmethod
+    def result(self) -> Optional[Any]:
+        """The result of the job."""
+
+    @property
+    @abstractmethod
+    def status(self) -> JobStatus:
+        """The status of the job."""
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.id.__eq__(other.id)
+
+    def __hash__(self):
+        return self.id.__hash__()

--- a/aiotruenas_client/machine.py
+++ b/aiotruenas_client/machine.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List
 
 from .disk import Disk
+from .job import Job, TJobId
 from .pool import Pool
 from .virtualmachine import VirtualMachine
 
@@ -15,6 +16,10 @@ class Machine(ABC):
     @abstractmethod
     async def get_disks(self, include_temperature: bool) -> List[Disk]:
         """Get the disks on the remote machine."""
+
+    @abstractmethod
+    async def get_job(self, id: TJobId) -> Job:
+        """Get the specified Job from the remote machine."""
 
     @abstractmethod
     async def get_system_info(self) -> Dict[str, Any]:

--- a/aiotruenas_client/websockets/disk.py
+++ b/aiotruenas_client/websockets/disk.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
 from ..disk import Disk, DiskType
+from .interfaces import WebsocketMachine
 
-TCachingMachine = TypeVar("TCachingMachine", bound="TCachingMachine")
 TCachingDiskStateFetcher = TypeVar(
     "TCachingDiskStateFetcher", bound="CachingDiskStateFetcher"
 )
@@ -74,12 +74,12 @@ class CachingDisk(Disk):
 
 
 class CachingDiskStateFetcher(object):
-    _parent: TCachingMachine
+    _parent: WebsocketMachine
     _state: Dict[str, Dict[str, Any]]
     _cached_disks: List[CachingDisk]
     _fetch_temperature: bool
 
-    def __init__(self, machine: TCachingMachine) -> None:
+    def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
         self._state = {}
         self._cached_disks = []
@@ -100,8 +100,7 @@ class CachingDiskStateFetcher(object):
         return self._state[disk.serial]
 
     async def _fetch_disks(self) -> Dict[str, Dict[str, Any]]:
-        assert self._parent._client is not None
-        disks = await self._parent._client.invoke_method(
+        disks = await self._parent._invoke_method(
             "disk.query",
             [
                 [],
@@ -119,7 +118,7 @@ class CachingDiskStateFetcher(object):
         )
         disks_by_name = {disk["name"]: disk for disk in disks}
         if len(disks_by_name) > 0 and self._fetch_temperature:
-            temps = await self._parent._client.invoke_method(
+            temps = await self._parent._invoke_method(
                 "disk.temperatures",
                 [
                     [disk for disk in disks_by_name],

--- a/aiotruenas_client/websockets/interfaces.py
+++ b/aiotruenas_client/websockets/interfaces.py
@@ -1,0 +1,55 @@
+from abc import abstractmethod
+from typing import Any, List, Optional, TypeVar
+
+from ..machine import Machine
+
+TWebsocketMachine = TypeVar("TWebsocketMachine", bound="WebsocketMachine")
+
+
+class WebsocketMachine(Machine):
+    @staticmethod
+    @abstractmethod
+    async def create(
+        cls,
+        host: str,
+        api_key: Optional[str] = None,
+        password: Optional[str] = None,
+        username: Optional[str] = None,
+        secure: bool = True,
+    ) -> TWebsocketMachine:
+        """Factory method to create a Websocket-based Machine class.
+
+        This method will automatically connect to the remote machine.
+
+        Only one of `api_key` or (`password` and `username`) can be provided.
+        """
+
+    @abstractmethod
+    async def connect(
+        self,
+        host: str,
+        api_key: Optional[str],
+        password: Optional[str],
+        username: Optional[str],
+        secure: bool,
+    ) -> None:
+        """Initializes the connection to the server.
+
+        Only one of `api_key` or (`password` and `username`) can be provided.
+        """
+
+    @abstractmethod
+    async def close(self) -> None:
+        """Closes the conenction to the server."""
+
+    @property
+    @abstractmethod
+    def closed(self) -> bool:
+        """If the connection to the server is closed or not."""
+
+    @abstractmethod
+    async def _invoke_method(self, method: str, params: List[Any] = []) -> Any:
+        """Invokes a method and returns its result.
+
+        This should only be used by internal classes to this library.
+        """

--- a/aiotruenas_client/websockets/job.py
+++ b/aiotruenas_client/websockets/job.py
@@ -1,0 +1,59 @@
+from typing import Any, Dict, Optional, TypeVar
+
+from ..job import Job, JobStatus, TJobId
+from .interfaces import WebsocketMachine
+
+TCachingJobFetcher = TypeVar("TCachingJobFetcher", bound="CachingJobFetcher")
+
+
+class CachingJob(Job):
+    def __init__(
+        self,
+        fetcher: TCachingJobFetcher,
+        id: TJobId,
+        method: str,
+    ) -> None:
+        super().__init__(id=id, method=method)
+        self._fetcher = fetcher
+        self._cached_state = self._state
+
+    @property
+    def error(self) -> Optional[str]:
+        """The error message from the API."""
+        return self._state["error"]
+
+    @property
+    def result(self) -> Optional[Any]:
+        """The result of the job."""
+        return self._state["result"]
+
+    @property
+    def status(self) -> JobStatus:
+        """The state of the job."""
+        return JobStatus.fromValue(self._state["state"])
+
+    @property
+    def _state(self) -> Dict[str, Any]:
+        """The state of the job, according to the fetcher."""
+        return self._fetcher._get_cached_state(self)
+
+
+class CachingJobFetcher(object):
+    _parent: WebsocketMachine
+    # This is probably not the best approach, as this will grow unbounded over time...
+    _state: Dict[TJobId, Dict[str, Any]]
+
+    def __init__(self, machine: WebsocketMachine) -> None:
+        self._parent = machine
+        self._state = {}
+        # TODO: subscribe to core.get_jobs so we get data real-time
+
+    async def get_job(self, id: TJobId) -> CachingJob:
+        if id not in self._state:
+            jobs = await self._parent._invoke_method("core.get_jobs", ["id", "=", id])
+            self._state[id] = jobs[0]
+
+        return CachingJob(fetcher=self, id=id, method=self._state[id]["method"])
+
+    def _get_cached_state(self, job: Job) -> Dict[str, Any]:
+        return self._state[job.id]

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -2,6 +2,8 @@ import ssl
 from typing import Any, Dict, List, Optional, TypeVar
 
 import websockets
+from aiotruenas_client.job import TJobId
+from aiotruenas_client.websockets.job import CachingJob, CachingJobFetcher
 
 from .disk import CachingDisk, CachingDiskStateFetcher
 from .interfaces import WebsocketMachine
@@ -21,11 +23,13 @@ class CachingMachine(WebsocketMachine):
 
     _client: Optional[TrueNASWebSocketClientProtocol] = None
     _disk_fetcher: CachingDiskStateFetcher
+    _job_fetcher: CachingJobFetcher
     _pool_fetcher: CachingPoolStateFetcher
     _vm_fetcher: CachingVirtualMachineStateFetcher
 
     def __init__(self) -> None:
         self._disk_fetcher = CachingDiskStateFetcher(self)
+        self._job_fetcher = CachingJobFetcher(self)
         self._pool_fetcher = CachingPoolStateFetcher(self)
         self._vm_fetcher = CachingVirtualMachineStateFetcher(self)
         super().__init__()
@@ -97,6 +101,10 @@ class CachingMachine(WebsocketMachine):
     def disks(self) -> List[CachingDisk]:
         """Returns a list of cached disks attached to the host."""
         return self._disk_fetcher.disks
+
+    async def get_job(self, id: TJobId) -> CachingJob:
+        """Get the specified Job from the remote machine."""
+        return await self._job_fetcher.get_job(id=id)
 
     async def get_system_info(self) -> Dict[str, Any]:
         """Get some basic information about the remote machine."""

--- a/aiotruenas_client/websockets/pool.py
+++ b/aiotruenas_client/websockets/pool.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, List, TypeVar
 
 from ..pool import Pool, PoolStatus
+from .interfaces import WebsocketMachine
 
-TCachingMachine = TypeVar("TCachingMachine", bound="TCachingMachine")
 TCachingPoolStateFetcher = TypeVar(
     "TCachingPoolStateFetcher", bound="CachingPoolStateFetcher"
 )
@@ -74,11 +74,11 @@ class CachingPool(Pool):
 
 
 class CachingPoolStateFetcher(object):
-    _parent: TCachingMachine
+    _parent: WebsocketMachine
     _state: Dict[str, Dict[str, Any]]
     _cached_pools: List[CachingPool]
 
-    def __init__(self, machine: TCachingMachine) -> None:
+    def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
         self._state = {}
         self._cached_pools = []
@@ -98,8 +98,7 @@ class CachingPoolStateFetcher(object):
         return self._state[pool.guid]
 
     async def _fetch_pools(self) -> Dict[str, Dict[str, Any]]:
-        assert self._parent._client is not None
-        pools = await self._parent._client.invoke_method(
+        pools = await self._parent._invoke_method(
             "pool.query",
             [
                 [],

--- a/scripts/invoke_method.py
+++ b/scripts/invoke_method.py
@@ -67,7 +67,7 @@ async def invoke_method(
         api_key=api_key,
         secure=secure,
     )
-    result = await machine._client.invoke_method(method, args)
+    result = await machine._invoke_method(method, args)
     pprint.pprint(result)
 
 

--- a/tests/websockets/test_job.py
+++ b/tests/websockets/test_job.py
@@ -1,0 +1,157 @@
+import datetime
+import unittest
+from unittest import IsolatedAsyncioTestCase
+
+from aiotruenas_client.job import JobStatus
+from aiotruenas_client.websockets import CachingMachine
+from aiotruenas_client.websockets.job import CachingJob
+from tests.fakes.fakeserver import TrueNASServer
+
+
+class TestJob(IsolatedAsyncioTestCase):
+    _server: TrueNASServer
+    _machine: CachingMachine
+
+    def setUp(self):
+        self._server = TrueNASServer()
+
+    async def asyncSetUp(self):
+        self._machine = await CachingMachine.create(
+            self._server.host,
+            api_key=self._server.api_key,
+            secure=False,
+        )
+
+    async def asyncTearDown(self):
+        await self._machine.close()
+        await self._server.stop()
+
+    async def test_running_data_interpretation(self) -> None:
+        JOB_ID = 42
+        self._server.register_method_handler(
+            "core.get_jobs",
+            lambda *args: [
+                {
+                    "arguments": ["jail01"],
+                    "error": None,
+                    "exc_info": None,
+                    "exception": None,
+                    "id": JOB_ID,
+                    "logs_excerpt": None,
+                    "logs_path": None,
+                    "method": "jail.start",
+                    "progress": {"description": None, "extra": None, "percent": None},
+                    "result": None,
+                    "state": "RUNNING",
+                    "time_finished": None,
+                    "time_started": datetime.datetime(
+                        2021, 1, 6, 17, 51, 29, 741000, tzinfo=datetime.timezone.utc
+                    ),
+                },
+            ],
+        )
+
+        job = await self._machine.get_job(42)
+        self.assertEqual(job.id, JOB_ID)
+        self.assertEqual(job.method, "jail.start")
+        self.assertEqual(job.status, JobStatus.RUNNING)
+
+    async def test_success_data_interpretation(self) -> None:
+        JOB_ID = 42
+        self._server.register_method_handler(
+            "core.get_jobs",
+            lambda *args: [
+                {
+                    "arguments": ["jail01"],
+                    "error": None,
+                    "exc_info": None,
+                    "exception": None,
+                    "id": JOB_ID,
+                    "logs_excerpt": None,
+                    "logs_path": None,
+                    "method": "jail.start",
+                    "progress": {"description": None, "extra": None, "percent": 100},
+                    "result": True,
+                    "state": "SUCCESS",
+                    "time_finished": datetime.datetime(
+                        2021, 1, 6, 17, 51, 41, 281000, tzinfo=datetime.timezone.utc
+                    ),
+                    "time_started": datetime.datetime(
+                        2021, 1, 6, 17, 51, 29, 741000, tzinfo=datetime.timezone.utc
+                    ),
+                }
+            ],
+        )
+
+        job = await self._machine.get_job(42)
+        self.assertEqual(job.id, JOB_ID)
+        self.assertEqual(job.method, "jail.start")
+        self.assertEqual(job.result, True)
+        self.assertEqual(job.status, JobStatus.SUCCESS)
+
+    async def test_failed_data_interpretation(self) -> None:
+        JOB_ID = 42
+        self._server.register_method_handler(
+            "core.get_jobs",
+            lambda *args: [
+                {
+                    "arguments": ["jail01"],
+                    "error": "[EFAULT] jail01 is not running",
+                    "exc_info": {"extra": None, "type": "CallError"},
+                    "exception": "Traceback (most recent call last):...",
+                    "id": JOB_ID,
+                    "logs_excerpt": None,
+                    "logs_path": None,
+                    "method": "jail.stop",
+                    "progress": {"description": None, "extra": None, "percent": None},
+                    "result": None,
+                    "state": "FAILED",
+                    "time_finished": datetime.datetime(
+                        2021, 1, 6, 5, 22, 38, 286000, tzinfo=datetime.timezone.utc
+                    ),
+                    "time_started": datetime.datetime(
+                        2021, 1, 6, 5, 22, 37, 945000, tzinfo=datetime.timezone.utc
+                    ),
+                }
+            ],
+        )
+
+        job = await self._machine.get_job(42)
+        self.assertEqual(job.error, "[EFAULT] jail01 is not running")
+        self.assertEqual(job.id, JOB_ID)
+        self.assertEqual(job.method, "jail.stop")
+        self.assertEqual(job.status, JobStatus.FAILED)
+
+    async def test_waiting_data_interpretation(self) -> None:
+        JOB_ID = 42
+        self._server.register_method_handler(
+            "core.get_jobs",
+            lambda *args: [
+                {
+                    "arguments": ["jail01"],
+                    "error": None,
+                    "exc_info": None,
+                    "exception": None,
+                    "id": JOB_ID,
+                    "logs_excerpt": None,
+                    "logs_path": None,
+                    "method": "jail.stop",
+                    "progress": {"description": None, "extra": None, "percent": None},
+                    "result": None,
+                    "state": "WAITING",
+                    "time_finished": None,
+                    "time_started": datetime.datetime(
+                        2021, 1, 6, 18, 8, 38, 561000, tzinfo=datetime.timezone.utc
+                    ),
+                },
+            ],
+        )
+
+        job = await self._machine.get_job(42)
+        self.assertEqual(job.id, JOB_ID)
+        self.assertEqual(job.method, "jail.stop")
+        self.assertEqual(job.status, JobStatus.WAITING)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds support for Jobs, which TrueNAS uses to track the progress of
long-running tasks.  We need this to determine the result of
long-running calls to do things like start and stop jails and VMs.

This has a bit of a flaw in that it will hold onto job data forever.  At
some point, we'll want to change this to throw away data after a period
of time, but this is probably good enough for now.


To accomplish this, this also includes a refactor that pulls out the websocket-specific methods we need for a `Machine` into
its own interface to clean up some abstractions used in the various fetchers.

This allows us to circumvent a typing issues where the fetchers reference the `CachingMachine`, and the `CachingMachine` references the files, which would otherwise require us to have one big file for everything.