### PR TITLE
Refactor: Add an interface for state fetchers

### DIFF
--- a/aiotruenas_client/websockets/disk.py
+++ b/aiotruenas_client/websockets/disk.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
 from ..disk import Disk, DiskType
-from .interfaces import WebsocketMachine
+from .interfaces import StateFetcher, WebsocketMachine
 
 TCachingDiskStateFetcher = TypeVar(
     "TCachingDiskStateFetcher", bound="CachingDiskStateFetcher"
@@ -73,7 +73,7 @@ class CachingDisk(Disk):
         return self._fetcher._get_cached_state(self)
 
 
-class CachingDiskStateFetcher(object):
+class CachingDiskStateFetcher(StateFetcher):
     _parent: WebsocketMachine
     _state: Dict[str, Dict[str, Any]]
     _cached_disks: List[CachingDisk]
@@ -83,6 +83,14 @@ class CachingDiskStateFetcher(object):
         self._parent = machine
         self._state = {}
         self._cached_disks = []
+
+    @classmethod
+    async def create(
+        cls,
+        machine: WebsocketMachine,
+    ) -> TCachingDiskStateFetcher:
+        cdsf = CachingDiskStateFetcher(machine=machine)
+        return cdsf
 
     async def get_disks(self, include_temperature: bool = False) -> List[CachingDisk]:
         """Returns a list of disks attached to the host."""

--- a/aiotruenas_client/websockets/interfaces.py
+++ b/aiotruenas_client/websockets/interfaces.py
@@ -1,9 +1,21 @@
-from abc import abstractmethod
+import asyncio
+from abc import ABC, abstractmethod
 from typing import Any, List, Optional, TypeVar
 
 from ..machine import Machine
 
+TStateFetcher = TypeVar("TStateFetcher", bound="StateFetcher")
 TWebsocketMachine = TypeVar("TWebsocketMachine", bound="WebsocketMachine")
+
+
+class StateFetcher(ABC):
+    @classmethod
+    @abstractmethod
+    async def create(
+        cls,
+        machine: TWebsocketMachine,
+    ) -> TStateFetcher:
+        """Factory method to create the state fetcher and setup any subscriptions."""
 
 
 class WebsocketMachine(Machine):

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -27,13 +27,6 @@ class CachingMachine(WebsocketMachine):
     _pool_fetcher: CachingPoolStateFetcher
     _vm_fetcher: CachingVirtualMachineStateFetcher
 
-    def __init__(self) -> None:
-        self._disk_fetcher = CachingDiskStateFetcher(self)
-        self._job_fetcher = CachingJobFetcher(self)
-        self._pool_fetcher = CachingPoolStateFetcher(self)
-        self._vm_fetcher = CachingVirtualMachineStateFetcher(self)
-        super().__init__()
-
     @classmethod
     async def create(
         cls,
@@ -51,6 +44,11 @@ class CachingMachine(WebsocketMachine):
             username=username,
             secure=secure,
         )
+        m._job_fetcher = await CachingJobFetcher.create(machine=m)
+
+        m._disk_fetcher = await CachingDiskStateFetcher.create(machine=m)
+        m._pool_fetcher = await CachingPoolStateFetcher.create(machine=m)
+        m._vm_fetcher = await CachingVirtualMachineStateFetcher.create(machine=m)
         return m
 
     async def connect(

--- a/aiotruenas_client/websockets/pool.py
+++ b/aiotruenas_client/websockets/pool.py
@@ -83,6 +83,14 @@ class CachingPoolStateFetcher(object):
         self._state = {}
         self._cached_pools = []
 
+    @classmethod
+    async def create(
+        cls,
+        machine: WebsocketMachine,
+    ) -> TCachingPoolStateFetcher:
+        cpsf = CachingPoolStateFetcher(machine=machine)
+        return cpsf
+
     async def get_pools(self) -> List[CachingPool]:
         """Returns a list of pools known to the host."""
         self._state = await self._fetch_pools()

--- a/aiotruenas_client/websockets/virtualmachine.py
+++ b/aiotruenas_client/websockets/virtualmachine.py
@@ -69,6 +69,14 @@ class CachingVirtualMachineStateFetcher(object):
         self._state = {}
         self._cached_vms = []
 
+    @classmethod
+    async def create(
+        cls,
+        machine: WebsocketMachine,
+    ) -> TCachingVirtualMachineStateFetcher:
+        cvmsf = CachingVirtualMachineStateFetcher(machine=machine)
+        return cvmsf
+
     async def get_vms(self) -> List[CachingVirtualMachine]:
         """Returns a list of virtual machines on the host."""
         self._state = await self._fetch_vms()


### PR DESCRIPTION
Depends on #53

This adds an interface and a new async, factory method for the fetchers
to be used in `CachingMachine`.