### PR TITLE
[fix] Multiple clients subscribing to the same subscription should not throw

### DIFF
--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -49,15 +49,14 @@ class SubscriptionData:
 
 
 class TrueNASWebSocketClientProtocol(WebSocketClientProtocol):
-    # Keyed by the id of the invoke message.
-    _invoke_method_futures: Dict[str, asyncio.Future] = {}
-    # Keyed by the id of the subscribing message.
-    _pending_subscription_data: Dict[str, PendingSubscriptionData] = {}
-    # Keyed be the "name" when subscribing, which is the "collection" when data comes in.
-    _subscription_data: Dict[str, SubscriptionData] = {}
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # Keyed by the id of the invoke message.
+        self._invoke_method_futures: Dict[str, asyncio.Future] = {}
+        # Keyed by the id of the subscribing message.
+        self._pending_subscription_data: Dict[str, PendingSubscriptionData] = {}
+        # Keyed be the "name" when subscribing, which is the "collection" when data comes in.
+        self._subscription_data: Dict[str, SubscriptionData] = {}
 
     async def handshake(self, *args, **kwargs):
         await WebSocketClientProtocol.handshake(self, *args, **kwargs)

--- a/tests/websockets/test_protocol.py
+++ b/tests/websockets/test_protocol.py
@@ -1,0 +1,43 @@
+from typing import cast
+from unittest.async_case import IsolatedAsyncioTestCase
+
+from aiotruenas_client.websockets.protocol import (
+    TrueNASWebSocketClientProtocol,
+    truenas_api_key_auth_protocol_factory,
+)
+from tests.fakes.fakeserver import TrueNASServer
+from websockets.legacy.client import connect
+
+
+class TestProtocolSubscriptions(IsolatedAsyncioTestCase):
+    _server: TrueNASServer
+
+    def setUp(self):
+        self._server = TrueNASServer()
+
+    async def asyncTearDown(self):
+        await self._server.stop()
+
+    async def test_two_clients_subscribe(self):
+        auth_protocol = truenas_api_key_auth_protocol_factory(self._server.api_key)
+        client1 = cast(
+            TrueNASWebSocketClientProtocol,
+            await connect(
+                f"ws://{self._server.host}/websocket",
+                create_protocol=auth_protocol,
+            ),
+        )
+        client2 = cast(
+            TrueNASWebSocketClientProtocol,
+            await connect(
+                f"ws://{self._server.host}/websocket",
+                create_protocol=auth_protocol,
+            ),
+        )
+
+        try:
+            queue1 = await client1.subscribe(name="test")
+            queue2 = await client2.subscribe(name="test")
+        finally:
+            await client1.close()
+            await client2.close()


### PR DESCRIPTION
The code was relying on class variables instead of instance variables, which meant multiple clients shared the same data.