### PR TITLE
Rely more on PEP256 Instance Variable Annotations

### DIFF
--- a/aiotruenas_client/jail.py
+++ b/aiotruenas_client/jail.py
@@ -19,8 +19,6 @@ class JailStatus(Enum):
 
 
 class Jail(ABC):
-    _name: str
-
     def __init__(self, name: str) -> None:
         self._name = name
 

--- a/aiotruenas_client/websockets/disk.py
+++ b/aiotruenas_client/websockets/disk.py
@@ -72,15 +72,12 @@ class CachingDisk(Disk):
 
 
 class CachingDiskStateFetcher(StateFetcher):
-    _parent: WebsocketMachine
-    _state: Dict[str, Dict[str, Any]]
-    _cached_disks: List[CachingDisk]
     _fetch_temperature: bool
 
     def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
-        self._state = {}
-        self._cached_disks = []
+        self._state: Dict[str, Dict[str, Any]] = {}
+        self._cached_disks: List[CachingDisk] = []
 
     @classmethod
     async def create(

--- a/aiotruenas_client/websockets/jail.py
+++ b/aiotruenas_client/websockets/jail.py
@@ -42,14 +42,10 @@ class CachingJail(Jail):
 
 
 class CachingJailStateFetcher(StateFetcher):
-    _parent: WebsocketMachine
-    _state: Dict[str, Dict[str, Any]]
-    _cached_jails: List[CachingJail]
-
     def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
-        self._state = {}
-        self._cached_jails = []
+        self._state: Dict[str, Dict[str, Any]] = {}
+        self._cached_jails: List[CachingJail] = []
 
     @classmethod
     async def create(

--- a/aiotruenas_client/websockets/job.py
+++ b/aiotruenas_client/websockets/job.py
@@ -43,15 +43,13 @@ class CachingJob(Job):
 
 
 class CachingJobFetcher(StateFetcher, Subscriber):
-    _job_wait_futures: Dict[TJobId, asyncio.Future] = {}
-    _parent: WebsocketMachine
-    # This is probably not the best approach, as this will grow unbounded over time...
-    _state: Dict[TJobId, Dict[str, Any]]
     _subscription_task: asyncio.Task
 
     def __init__(self, machine: WebsocketMachine) -> None:
+        self._job_wait_futures: Dict[TJobId, asyncio.Future] = {}
         self._parent = machine
-        self._state = {}
+        # This is probably not the best approach, as this will grow unbounded over time...
+        self._state: Dict[TJobId, Dict[str, Any]] = {}
 
     @classmethod
     async def create(

--- a/aiotruenas_client/websockets/machine.py
+++ b/aiotruenas_client/websockets/machine.py
@@ -26,14 +26,15 @@ logger = logging.getLogger(__name__)
 class CachingMachine(WebsocketMachine):
     """A Machine implementation that connects over websockets and keeps fetched information in-sync with the server."""
 
-    _client: Optional[TrueNASWebSocketClientProtocol] = None
-    _subscribers: List[Subscriber] = []
-
     _disk_fetcher: CachingDiskStateFetcher
     _jail_fetcher: CachingJailStateFetcher
     _job_fetcher: CachingJobFetcher
     _pool_fetcher: CachingPoolStateFetcher
     _vm_fetcher: CachingVirtualMachineStateFetcher
+
+    def __init__(self):
+        self._client: Optional[TrueNASWebSocketClientProtocol] = None
+        self._subscribers: List[Subscriber] = []
 
     @classmethod
     async def create(

--- a/aiotruenas_client/websockets/pool.py
+++ b/aiotruenas_client/websockets/pool.py
@@ -72,14 +72,10 @@ class CachingPool(Pool):
 
 
 class CachingPoolStateFetcher(object):
-    _parent: WebsocketMachine
-    _state: Dict[str, Dict[str, Any]]
-    _cached_pools: List[CachingPool]
-
     def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
-        self._state = {}
-        self._cached_pools = []
+        self._state: Dict[str, Dict[str, Any]] = {}
+        self._cached_pools: List[CachingPool] = []
 
     @classmethod
     async def create(

--- a/aiotruenas_client/websockets/protocol.py
+++ b/aiotruenas_client/websockets/protocol.py
@@ -15,9 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 class PendingSubscriptionData:
-    _name: str
-    _future: asyncio.Future
-
     def __init__(self, name: str, future: asyncio.Future) -> None:
         self._name = name
         self._future = future
@@ -32,9 +29,6 @@ class PendingSubscriptionData:
 
 
 class SubscriptionData:
-    _id: str
-    _queue: asyncio.Queue
-
     def __init__(self, id: str, queue: asyncio.Queue) -> None:
         self._id = id
         self._queue = queue

--- a/aiotruenas_client/websockets/virtualmachine.py
+++ b/aiotruenas_client/websockets/virtualmachine.py
@@ -58,14 +58,10 @@ class CachingVirtualMachine(VirtualMachine):
 
 
 class CachingVirtualMachineStateFetcher(object):
-    _parent: WebsocketMachine
-    _state: Dict[str, Dict[str, Any]]
-    _cached_vms: List[CachingVirtualMachine]
-
     def __init__(self, machine: WebsocketMachine) -> None:
         self._parent = machine
-        self._state = {}
-        self._cached_vms = []
+        self._state: Dict[str, Dict[str, Any]] = {}
+        self._cached_vms: List[CachingVirtualMachine] = []
 
     @classmethod
     async def create(


### PR DESCRIPTION
This helps prevent a foot-gun of accidentially having class variables
shared across instances when we do not set the value in `__init__`.

See https://www.python.org/dev/peps/pep-0526/#class-and-instance-variable-annotations