### PR TITLE
Re-enable disabled test

### DIFF
--- a/tests/websockets/test_machine.py
+++ b/tests/websockets/test_machine.py
@@ -117,22 +117,21 @@ class TestCachingMachineGetSystemInfo(IsolatedAsyncioTestCase):
         self.assertEqual(info["hostname"], HOSTNAME)
 
 
-# TODO: for some undiscovered reason, this test prevents subsequent tests from passing with pytest.
-# class TestCachingMachineClosed(IsolatedAsyncioTestCase):
-#     def setUp(self):
-#         self._server = TrueNASServer()
+class TestCachingMachineClosed(IsolatedAsyncioTestCase):
+    def setUp(self):
+        self._server = TrueNASServer()
 
-#     async def test_closed(self) -> None:
-#         machine = await CachingMachine.create(
-#             self._server.host,
-#             api_key=self._server.api_key,
-#             secure=False,
-#         )
+    async def test_closed(self) -> None:
+        machine = await CachingMachine.create(
+            self._server.host,
+            api_key=self._server.api_key,
+            secure=False,
+        )
 
-#         self.assertFalse(machine.closed)
+        self.assertFalse(machine.closed)
 
-#         await self._server.stop()
-#         self.assertTrue(machine.closed)
+        await self._server.stop()
+        self.assertTrue(machine.closed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This test was disabled due to a bug I could not track down that would
hang the test suite.  In hindsight, I think that
20ea3b6e4214b727495e9466a854b29610a96bf2 probably fixed this issue.