### PR TITLE
fix dataset comments

### DIFF
--- a/aiotruenas_client/websockets/dataset.py
+++ b/aiotruenas_client/websockets/dataset.py
@@ -27,7 +27,9 @@ class CachingDataset(Dataset):
     @property
     def comments(self) -> Optional[DatasetProperty]:
         """The user-provided comments on the dataset."""
-        return self._get_property("comments")
+        property = self._get_property("comments")
+        assert property is not None
+        return property.parsedValue
 
     @property
     def compression_ratio(self) -> float:


### PR DESCRIPTION
While working on hass-truenas, I noticed that the `comments` wasn't returning the desired value. This fixes that. The only thing that relies on this is the `comments` attribute for datasets in hass-truenas, which I can hold off on adding if you want to wait to merge this. 